### PR TITLE
docs: add trailing '.' to `dns_name` example

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -76,7 +76,7 @@ suffix and has a set of name servers that accept and responds to queries:
 
      >>> from google.cloud import dns
      >>> client = dns.Client(project='PROJECT_ID')
-     >>> zone = client.zone('acme-co', 'example.com',
+     >>> zone = client.zone('acme-co', 'example.com.', #dns_name requires trailing dot
      ...                    description='Acme Company zone')
 
      >>> zone.exists()  # API request


### PR DESCRIPTION
The shown example to create a zone will not work. The api required a trailing dot for the dns_name. In the GCP console this is visible if you display the rest call. However in the documentation it is not. Without the trailing dot the following exception occurs on zone.create():
*** google.api_core.exceptions.BadRequest: 400 POST https://dns.googleapis.com/dns/v1/projects/urlshortener-257711/managedZones: Invalid value for 'entity.managedZone.dnsName': 'test.de'

zone = client.zone('acme-co', 'example.com', <=Missing trailing dot
     ...                    description='Acme Company zone')

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-dns/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
