### PR TITLE
test: update tests to support latest google-cloud-core

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ version = "0.32.0"
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 3 - Alpha"
-dependencies = ["google-cloud-core == 1.4.2rc2"]
+dependencies = ["google-cloud-core >= 1.1.0, < 2.0dev"]
 extras = {}
 
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ version = "0.32.0"
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 3 - Alpha"
-dependencies = ["google-cloud-core >= 1.1.0, < 2.0dev"]
+dependencies = ["google-cloud-core == 1.4.2rc1"]
 extras = {}
 
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ version = "0.32.0"
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 3 - Alpha"
-dependencies = ["google-cloud-core == 1.4.2rc1"]
+dependencies = ["google-cloud-core == 1.4.2rc2"]
 extras = {}
 
 


### PR DESCRIPTION
`google-cloud-core` version 1.4.2 populates `prettyPrint=false` by
default. Update the connection tests to expect a value for
`prettyPrint`.

This PR also serves to test that the changes in googleapis/python-cloud-core#28 do not break this library.