### PR TITLE
chore: reference main branch of google-cloud-python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ manage DNS for your applications.
 - `Product Documentation`_
 
 .. |alpha| image:: https://img.shields.io/badge/support-alpha-orange.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#alpha-support
+   :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#alpha-support
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-dns.svg
    :target: https://pypi.org/project/google-cloud-dns/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-dns.svg


### PR DESCRIPTION
Adjust google-cloud-python links to reference main branch.