### PR TITLE
fix: remove six

### DIFF
--- a/google/cloud/dns/changes.py
+++ b/google/cloud/dns/changes.py
@@ -14,8 +14,6 @@
 
 """Define API ResourceRecordSets."""
 
-import six
-
 from google.cloud._helpers import _rfc3339_to_datetime
 from google.cloud.exceptions import NotFound
 from google.cloud.dns.resource_record_set import ResourceRecordSet
@@ -105,7 +103,7 @@ class Changes(object):
         :type value: str
         :param value: New name for the changeset.
         """
-        if not isinstance(value, six.string_types):
+        if not isinstance(value, str):
             raise ValueError("Pass a string")
         self._properties["id"] = value
 

--- a/google/cloud/dns/zone.py
+++ b/google/cloud/dns/zone.py
@@ -14,8 +14,6 @@
 
 """Define API ManagedZones."""
 
-import six
-
 from google.api_core import page_iterator
 from google.cloud._helpers import _rfc3339_to_datetime
 from google.cloud.exceptions import NotFound
@@ -143,7 +141,7 @@ class ManagedZone(object):
 
         :raises: ValueError for invalid value types.
         """
-        if not isinstance(value, six.string_types) and value is not None:
+        if not isinstance(value, str) and value is not None:
             raise ValueError("Pass a string, or None")
         self._properties["description"] = value
 
@@ -170,7 +168,7 @@ class ManagedZone(object):
 
         :raises: ValueError for invalid value types.
         """
-        if not isinstance(value, six.string_types) and value is not None:
+        if not isinstance(value, str) and value is not None:
             raise ValueError("Pass a string, or None")
         self._properties["nameServerSet"] = value
 

--- a/tests/unit/test__http.py
+++ b/tests/unit/test__http.py
@@ -28,8 +28,8 @@ class TestConnection(unittest.TestCase):
         return self._get_target_class()(*args, **kw)
 
     def test_build_api_url_no_extra_query_params(self):
-        from six.moves.urllib.parse import parse_qsl
-        from six.moves.urllib.parse import urlsplit
+        from urllib.parse import parse_qsl
+        from urllib.parse import urlsplit
 
         conn = self._make_one(object())
         uri = conn.build_api_url("/foo")
@@ -42,8 +42,8 @@ class TestConnection(unittest.TestCase):
         self.assertEqual(parms, {})
 
     def test_build_api_url_w_custom_endpoint(self):
-        from six.moves.urllib.parse import parse_qsl
-        from six.moves.urllib.parse import urlsplit
+        from urllib.parse import parse_qsl
+        from urllib.parse import urlsplit
 
         custom_endpoint = "https://foo-dns.googleapis.com"
         conn = self._make_one(object(), api_endpoint=custom_endpoint)
@@ -57,8 +57,8 @@ class TestConnection(unittest.TestCase):
         self.assertEqual(parms, {})
 
     def test_build_api_url_w_extra_query_params(self):
-        from six.moves.urllib.parse import parse_qsl
-        from six.moves.urllib.parse import urlsplit
+        from urllib.parse import parse_qsl
+        from urllib.parse import urlsplit
 
         conn = self._make_one(object())
         uri = conn.build_api_url("/foo", {"bar": "baz"})

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -192,7 +192,6 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req["path"], "/%s" % PATH)
 
     def test_list_zones_defaults(self):
-        import six
         from google.cloud.dns.zone import ManagedZone
 
         ID_1 = "123"
@@ -225,7 +224,7 @@ class TestClient(unittest.TestCase):
         conn = client._connection = _Connection(DATA)
 
         iterator = client.list_zones()
-        page = six.next(iterator.pages)
+        page = next(iterator.pages)
         zones = list(page)
         token = iterator.next_page_token
 
@@ -243,7 +242,6 @@ class TestClient(unittest.TestCase):
         self.assertEqual(req["path"], "/%s" % PATH)
 
     def test_list_zones_explicit(self):
-        import six
         from google.cloud.dns.zone import ManagedZone
 
         ID_1 = "123"
@@ -275,7 +273,7 @@ class TestClient(unittest.TestCase):
         conn = client._connection = _Connection(DATA)
 
         iterator = client.list_zones(max_results=3, page_token=TOKEN)
-        page = six.next(iterator.pages)
+        page = next(iterator.pages)
         zones = list(page)
         token = iterator.next_page_token
 

--- a/tests/unit/test_zone.py
+++ b/tests/unit/test_zone.py
@@ -412,7 +412,6 @@ class TestManagedZone(unittest.TestCase):
         self.assertEqual(req["path"], "/%s" % PATH)
 
     def test_list_resource_record_sets_defaults(self):
-        import six
         from google.cloud.dns.resource_record_set import ResourceRecordSet
 
         PATH = "projects/%s/managedZones/%s/rrsets" % (self.PROJECT, self.ZONE_NAME)
@@ -450,7 +449,7 @@ class TestManagedZone(unittest.TestCase):
 
         iterator = zone.list_resource_record_sets()
         self.assertIs(zone, iterator.zone)
-        page = six.next(iterator.pages)
+        page = next(iterator.pages)
         rrsets = list(page)
         token = iterator.next_page_token
 
@@ -469,7 +468,6 @@ class TestManagedZone(unittest.TestCase):
         self.assertEqual(req["path"], "/%s" % PATH)
 
     def test_list_resource_record_sets_explicit(self):
-        import six
         from google.cloud.dns.resource_record_set import ResourceRecordSet
 
         PATH = "projects/%s/managedZones/%s/rrsets" % (self.PROJECT, self.ZONE_NAME)
@@ -510,7 +508,7 @@ class TestManagedZone(unittest.TestCase):
             max_results=3, page_token=TOKEN, client=client2
         )
         self.assertIs(zone, iterator.zone)
-        page = six.next(iterator.pages)
+        page = next(iterator.pages)
         rrsets = list(page)
         token = iterator.next_page_token
 
@@ -574,7 +572,6 @@ class TestManagedZone(unittest.TestCase):
         return result
 
     def test_list_changes_defaults(self):
-        import six
         from google.cloud.dns.changes import Changes
         from google.cloud.dns.resource_record_set import ResourceRecordSet
 
@@ -590,7 +587,7 @@ class TestManagedZone(unittest.TestCase):
 
         iterator = zone.list_changes()
         self.assertIs(zone, iterator.zone)
-        page = six.next(iterator.pages)
+        page = next(iterator.pages)
         changes = list(page)
         token = iterator.next_page_token
 
@@ -625,7 +622,6 @@ class TestManagedZone(unittest.TestCase):
         self.assertEqual(req["path"], "/%s" % (path,))
 
     def test_list_changes_explicit(self):
-        import six
         from google.cloud.dns.changes import Changes
         from google.cloud.dns.resource_record_set import ResourceRecordSet
 
@@ -644,7 +640,7 @@ class TestManagedZone(unittest.TestCase):
             max_results=3, page_token=page_token, client=client2
         )
         self.assertIs(zone, iterator.zone)
-        page = six.next(iterator.pages)
+        page = next(iterator.pages)
         changes = list(page)
         token = iterator.next_page_token
 


### PR DESCRIPTION
Remove six usage in this library. Six was used only for Python 2/3 compatibility.

Fixes #83, #84, #85, #86, #87, #88  🦕
