### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "dns",
     "name_pretty": "Cloud DNS",
     "product_documentation": "https://cloud.google.com/dns",
-    "client_documentation": "https://googleapis.dev/python/dns/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/dns/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559772",
     "release_level": "alpha",
     "language": "python",


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.