### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "dns",
     "name_pretty": "Cloud DNS",
     "product_documentation": "https://cloud.google.com/dns",
-    "client_documentation": "https://googleapis.dev/python/dns/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/dns/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559772",
     "release_level": "alpha",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ manage DNS for your applications.
    :target: https://pypi.org/project/google-cloud-dns/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-dns.svg
 .. _Google Cloud DNS: https://cloud.google.com/dns/
-.. _Client Library Documentation: https://googleapis.dev/python/dns/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/dns/latest
 .. _Product Documentation: https://cloud.google.com/dns/docs/
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.