### PR TITLE
add resourcePolicy property support to ResourceRecordSet

### DIFF
--- a/google/cloud/dns/changes.py
+++ b/google/cloud/dns/changes.py
@@ -188,25 +188,45 @@ class Changes(object):
             client = self.zone._client
         return client
 
+    @staticmethod
+    def _routing_policy_cleaner(rrs_dict):
+        """If ``routingPolicy`` or ``rrdatas`` are falsy, delete them.
+
+        :type rrs_dict: dict
+        :param rrs_dict: dict representation of a
+            :class:`google.cloud.dns.resource_record_set.ResourceRecordSet`.
+        """
+        if not rrs_dict["routingPolicy"]:
+            del rrs_dict["routingPolicy"]
+        if not rrs_dict["rrdatas"]:
+            del rrs_dict["rrdatas"]
+        return rrs_dict
+
     def _build_resource(self):
         """Generate a resource for ``create``."""
         additions = [
-            {
-                "name": added.name,
-                "type": added.record_type,
-                "ttl": str(added.ttl),
-                "rrdatas": added.rrdatas,
-            }
+            self._routing_policy_cleaner(
+                {
+                    "name": added.name,
+                    "type": added.record_type,
+                    "ttl": str(added.ttl),
+                    "rrdatas": added.rrdatas,
+                    "routingPolicy": added.routing_policy,
+                }
+            )
             for added in self.additions
         ]
 
         deletions = [
-            {
-                "name": deleted.name,
-                "type": deleted.record_type,
-                "ttl": str(deleted.ttl),
-                "rrdatas": deleted.rrdatas,
-            }
+            self._routing_policy_cleaner(
+                {
+                    "name": deleted.name,
+                    "type": deleted.record_type,
+                    "ttl": str(deleted.ttl),
+                    "rrdatas": deleted.rrdatas,
+                    "routingPolicy": deleted.routing_policy,
+                }
+            )
             for deleted in self.deletions
         ]
 

--- a/google/cloud/dns/resource_record_set.py
+++ b/google/cloud/dns/resource_record_set.py
@@ -35,15 +35,20 @@ class ResourceRecordSet(object):
     :type rrdatas: list of string
     :param rrdatas: one or more lines containing the resource data.
 
+    :type routing_policy: dict
+    :param routing_policy: a dict containing the record's routing_policy.
+        Pass an empty dict if not needed.
+
     :type zone: :class:`google.cloud.dns.zone.ManagedZone`
     :param zone: A zone which holds one or more record sets.
     """
 
-    def __init__(self, name, record_type, ttl, rrdatas, zone):
+    def __init__(self, name, record_type, ttl, rrdatas, routing_policy, zone):
         self.name = name
         self.record_type = record_type
         self.ttl = ttl
         self.rrdatas = rrdatas
+        self.routing_policy = routing_policy
         self.zone = zone
 
     @classmethod
@@ -62,5 +67,6 @@ class ResourceRecordSet(object):
         name = resource["name"]
         record_type = resource["type"]
         ttl = int(resource["ttl"])
-        rrdatas = resource["rrdatas"]
-        return cls(name, record_type, ttl, rrdatas, zone=zone)
+        rrdatas = resource.get("rrdatas", [])
+        routing_policy = resource.get("routingPolicy", {})
+        return cls(name, record_type, ttl, rrdatas, routing_policy, zone=zone)

--- a/google/cloud/dns/zone.py
+++ b/google/cloud/dns/zone.py
@@ -172,7 +172,7 @@ class ManagedZone(object):
             raise ValueError("Pass a string, or None")
         self._properties["nameServerSet"] = value
 
-    def resource_record_set(self, name, record_type, ttl, rrdatas):
+    def resource_record_set(self, name, record_type, ttl, rrdatas, routing_policy):
         """Construct a resource record set bound to this zone.
 
         :type name: str
@@ -187,10 +187,15 @@ class ManagedZone(object):
         :type rrdatas: list of string
         :param rrdatas: resource data for the RR
 
+        :type routing_policy: dict
+        :param routing_policy: a dict containing the record's routing_policy
+
         :rtype: :class:`google.cloud.dns.resource_record_set.ResourceRecordSet`
         :returns: a new ``ResourceRecordSet`` instance
         """
-        return ResourceRecordSet(name, record_type, ttl, rrdatas, zone=self)
+        return ResourceRecordSet(
+            name, record_type, ttl, rrdatas, routing_policy, zone=self
+        )
 
     def changes(self):
         """Construct a change set bound to this zone.

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ import setuptools
 
 name = "google-cloud-dns"
 description = "Google Cloud DNS API client library"
-version = "0.34.1"
+version = "0.35.0"
 # Should be one of:
 # 'Development Status :: 3 - Alpha'
 # 'Development Status :: 4 - Beta'

--- a/tests/unit/test_resource_record_set.py
+++ b/tests/unit/test_resource_record_set.py
@@ -29,23 +29,31 @@ class TestResourceRecordSet(unittest.TestCase):
         zone = _Zone()
 
         rrs = self._make_one(
-            "test.example.com", "CNAME", 3600, ["www.example.com"], zone
+            "test.example.com", "CNAME", 3600, ["www.example.com"], {}, zone
         )
 
         self.assertEqual(rrs.name, "test.example.com")
         self.assertEqual(rrs.record_type, "CNAME")
         self.assertEqual(rrs.ttl, 3600)
         self.assertEqual(rrs.rrdatas, ["www.example.com"])
+        self.assertEqual(rrs.routing_policy, {})
         self.assertIs(rrs.zone, zone)
 
     def test_from_api_repr_missing_rrdatas(self):
         zone = _Zone()
         klass = self._get_target_class()
 
-        with self.assertRaises(KeyError):
-            klass.from_api_repr(
-                {"name": "test.example.com", "type": "CNAME", "ttl": 3600}, zone=zone
-            )
+        rrs = klass.from_api_repr(
+            {
+                "name": "test.example.com",
+                "type": "CNAME",
+                "ttl": 3600,
+                "routingPolicy": {},
+            },
+            zone=zone,
+        )
+        self.assertTrue(hasattr(rrs, "rrdatas"))
+        self.assertEqual(rrs.rrdatas, [])
 
     def test_from_api_repr_missing_ttl(self):
         zone = _Zone()
@@ -57,6 +65,7 @@ class TestResourceRecordSet(unittest.TestCase):
                     "name": "test.example.com",
                     "type": "CNAME",
                     "rrdatas": ["www.example.com"],
+                    "routingPolicy": {},
                 },
                 zone=zone,
             )
@@ -71,6 +80,7 @@ class TestResourceRecordSet(unittest.TestCase):
                     "name": "test.example.com",
                     "ttl": 3600,
                     "rrdatas": ["www.example.com"],
+                    "routingPolicy": {},
                 },
                 zone=zone,
             )
@@ -81,9 +91,29 @@ class TestResourceRecordSet(unittest.TestCase):
 
         with self.assertRaises(KeyError):
             klass.from_api_repr(
-                {"type": "CNAME", "ttl": 3600, "rrdatas": ["www.example.com"]},
+                {
+                    "type": "CNAME",
+                    "ttl": 3600,
+                    "rrdatas": ["www.example.com"],
+                    "routingPolicy": {},
+                },
                 zone=zone,
             )
+
+    def test_from_api_repr_missing_routing_policy(self):
+        zone = _Zone()
+        klass = self._get_target_class()
+
+        rrs = klass.from_api_repr(
+            {
+                "name": "test.example.com",
+                "type": "CNAME",
+                "ttl": 3600,
+                "rrdatas": ["www.example.com"],
+            },
+            zone=zone,
+        )
+        self.assertEqual(rrs.routing_policy, {})
 
     def test_from_api_repr_bare(self):
         zone = _Zone()
@@ -93,6 +123,7 @@ class TestResourceRecordSet(unittest.TestCase):
             "type": "CNAME",
             "ttl": "3600",
             "rrdatas": ["www.example.com"],
+            "routingPolicy": {},
         }
         klass = self._get_target_class()
         rrs = klass.from_api_repr(RESOURCE, zone=zone)
@@ -101,6 +132,7 @@ class TestResourceRecordSet(unittest.TestCase):
         self.assertEqual(rrs.ttl, 3600)
         self.assertEqual(rrs.rrdatas, ["www.example.com"])
         self.assertIs(rrs.zone, zone)
+        self.assertEqual(rrs.routing_policy, {})
 
 
 class _Zone(object):

--- a/tests/unit/test_zone.py
+++ b/tests/unit/test_zone.py
@@ -68,6 +68,7 @@ class TestManagedZone(unittest.TestCase):
                 "ns-cloud1.googledomains.com",
                 "ns-cloud2.googledomains.com",
             ],
+            "routingPolicy": {},
         }
 
     def _verifyReadonlyResourceProperties(self, zone, resource):
@@ -194,9 +195,10 @@ class TestManagedZone(unittest.TestCase):
         RRS_TYPE = "CNAME"
         TTL = 3600
         RRDATAS = ["www.example.com"]
+        ROUTING_POLICY = {}
         client = _Client(self.PROJECT)
         zone = self._make_one(self.ZONE_NAME, self.DNS_NAME, client)
-        rrs = zone.resource_record_set(RRS_NAME, RRS_TYPE, TTL, RRDATAS)
+        rrs = zone.resource_record_set(RRS_NAME, RRS_TYPE, TTL, RRDATAS, ROUTING_POLICY)
         self.assertIsInstance(rrs, ResourceRecordSet)
         self.assertEqual(rrs.name, RRS_NAME)
         self.assertEqual(rrs.record_type, RRS_TYPE)
@@ -433,6 +435,7 @@ class TestManagedZone(unittest.TestCase):
                     "type": TYPE_1,
                     "ttl": TTL_1,
                     "rrdatas": RRDATAS_1,
+                    "routingPolicy": {},
                 },
                 {
                     "kind": "dns#resourceRecordSet",
@@ -440,6 +443,7 @@ class TestManagedZone(unittest.TestCase):
                     "type": TYPE_2,
                     "ttl": TTL_2,
                     "rrdatas": RRDATAS_2,
+                    "routingPolicy": {},
                 },
             ],
         }
@@ -488,6 +492,7 @@ class TestManagedZone(unittest.TestCase):
                     "type": TYPE_1,
                     "ttl": TTL_1,
                     "rrdatas": RRDATAS_1,
+                    "routingPolicy": {},
                 },
                 {
                     "kind": "dns#resourceRecordSet",
@@ -495,6 +500,7 @@ class TestManagedZone(unittest.TestCase):
                     "type": TYPE_2,
                     "ttl": TTL_2,
                     "rrdatas": RRDATAS_2,
+                    "routingPolicy": {},
                 },
             ]
         }
@@ -553,6 +559,7 @@ class TestManagedZone(unittest.TestCase):
                             "type": type_1,
                             "ttl": ttl_1,
                             "rrdatas": rrdatas_1,
+                            "routingPolicy": {},
                         }
                     ],
                     "deletions": [
@@ -562,6 +569,7 @@ class TestManagedZone(unittest.TestCase):
                             "type": type_2,
                             "ttl": ttl_2,
                             "rrdatas": rrdatas_2,
+                            "routingPolicy": {},
                         }
                     ],
                 }


### PR DESCRIPTION
- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-dns/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes googleapis/google-cloud-python#15428  🦕

Adds support for resourcePolicy property on ResourceRecordSets.

Creating a new `ResourceRecordSet()` now requires setting the `resource_policy` param, although an empty dict can be used if not required.

```
# no resourcePolicy required
rrs = ResourceRecordSet("foo.example.com.", "A", 3600, ["10.1.2.3"], {}, zone=zone)

# no resourcePolicy required
rrs_w_routing_policy = ResourceRecordSet("foo.example.com.", "A", 3600, [], {"geo": {...}}, zone=zone)
```

When creating a `ResourceRecordSet` with a `routingPolicy`, `rrdatas` needs to be empty, and vice-versa. `Changes._build_resource()` now calls a new helper method `_routing_policy_cleaner` to remove either key if empty. 

version bumped to 0.35.0 in setup.py, but CHANGELOG appears to be auto generated, so didn't touch. docstrings and unit tests updated.
