### PR TITLE
chore: fix library_type in repo-metadata

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -6,7 +6,7 @@
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559772",
     "release_level": "preview",
     "language": "python",
-    "library_type": "GAPIC_MANUAL",
+    "library_type": "REST",
     "repo": "googleapis/python-dns",
     "distribution_name": "google-cloud-dns",
     "requires_billing": true,


### PR DESCRIPTION
Switches `library_type` to `REST` as this is not a `GAPIC` and we don't want the repo-metadata linter to complain about it.

Fixes #134  🦕
