### PR TITLE
fix: require google-cloud-core >= 1.4.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ dependencies = [
     # NOTE: Maintainers, please do not require google-cloud-core>=2.x.x
     # Until this issue is closed
     # https://github.com/googleapis/google-cloud-python/issues/10566
-    "google-cloud-core >= 1.3.0, < 3.0dev",
+    "google-cloud-core >= 1.4.4, < 3.0dev",
 ]
 extras = {}
 

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -1,8 +1,0 @@
-# This constraints file is used to check that lower bounds
-# are correct in setup.py
-# List *all* library dependencies and extras in this file.
-# Pin the version to the lower bound.
-#
-# e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
-# Then this file should have foo==1.14.0
-google-cloud-core==1.3.0

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -5,4 +5,4 @@
 #
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
-google-cloud-core==1.3.0
+google-cloud-core==1.4.4


### PR DESCRIPTION
This also removes the transitive dependency on package "six", which was causing presubmit failures.