### PR TITLE
feat: Adds Python 3.13 support

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.8"
+        python-version: "3.10"
     - name: Install nox
       run: |
         python -m pip install --upgrade setuptools pip wheel

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.8"
     - name: Install nox
       run: |
         python -m pip install --upgrade setuptools pip wheel

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.8"
+        python-version: "3.10"
     - name: Install coverage
       run: |
         python -m pip install --upgrade setuptools pip wheel

--- a/.kokoro/presubmit/presubmit.cfg
+++ b/.kokoro/presubmit/presubmit.cfg
@@ -1,1 +1,6 @@
 # Format: //devtools/kokoro/config/proto/build.proto
+
+env_vars: {
+    key: "NOX_SESSION"
+    value: "system-3.12 blacken mypy format"
+}

--- a/.kokoro/presubmit/presubmit.cfg
+++ b/.kokoro/presubmit/presubmit.cfg
@@ -2,5 +2,5 @@
 
 env_vars: {
     key: "NOX_SESSION"
-    value: "system-3.10 blacken format"
+    value: "system blacken format"
 }

--- a/.kokoro/presubmit/presubmit.cfg
+++ b/.kokoro/presubmit/presubmit.cfg
@@ -1,6 +1,1 @@
 # Format: //devtools/kokoro/config/proto/build.proto
-
-env_vars: {
-    key: "NOX_SESSION"
-    value: "system-3.12 blacken mypy format"
-}

--- a/.kokoro/presubmit/presubmit.cfg
+++ b/.kokoro/presubmit/presubmit.cfg
@@ -2,5 +2,5 @@
 
 env_vars: {
     key: "NOX_SESSION"
-    value: "system-3.8 blacken format"
+    value: "system-3.10 blacken format"
 }

--- a/.kokoro/presubmit/presubmit.cfg
+++ b/.kokoro/presubmit/presubmit.cfg
@@ -2,5 +2,5 @@
 
 env_vars: {
     key: "NOX_SESSION"
-    value: "system-3.12 blacken mypy format"
+    value: "system-3.8 blacken format"
 }

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -143,12 +143,12 @@ Running System Tests
    $ nox -s system
 
    # Run a single system test
-   $ nox -s system-3.8 -- -k <name of test>
+   $ nox -s system-3.10 -- -k <name of test>
 
 
   .. note::
 
-      System tests are only configured to run under Python 3.8.
+      System tests are only configured to run under Python 3.10.
       For expediency, we do not run them in older versions of Python 3.
 
   This alone will not run the tests. You'll need to change some local

--- a/noxfile.py
+++ b/noxfile.py
@@ -32,7 +32,7 @@ BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
-DEFAULT_PYTHON_VERSION = "3.10"
+DEFAULT_PYTHON_VERSION = "3.8"
 
 UNIT_TEST_PYTHON_VERSIONS: List[str] = [
     "3.7",
@@ -56,7 +56,7 @@ UNIT_TEST_DEPENDENCIES: List[str] = []
 UNIT_TEST_EXTRAS: List[str] = []
 UNIT_TEST_EXTRAS_BY_PYTHON: Dict[str, List[str]] = {}
 
-SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.10"]
+SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.8"]
 SYSTEM_TEST_STANDARD_DEPENDENCIES: List[str] = [
     "mock",
     "pytest",

--- a/noxfile.py
+++ b/noxfile.py
@@ -32,7 +32,7 @@ BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
-DEFAULT_PYTHON_VERSION = "3.8"
+DEFAULT_PYTHON_VERSION = "3.10"
 
 UNIT_TEST_PYTHON_VERSIONS: List[str] = [
     "3.7",

--- a/noxfile.py
+++ b/noxfile.py
@@ -56,7 +56,7 @@ UNIT_TEST_DEPENDENCIES: List[str] = []
 UNIT_TEST_EXTRAS: List[str] = []
 UNIT_TEST_EXTRAS_BY_PYTHON: Dict[str, List[str]] = {}
 
-SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.10", "3.11", "3.12", "3.13"]
+SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.10"]
 SYSTEM_TEST_STANDARD_DEPENDENCIES: List[str] = [
     "mock",
     "pytest",

--- a/noxfile.py
+++ b/noxfile.py
@@ -32,7 +32,7 @@ BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
-DEFAULT_PYTHON_VERSION = "3.8"
+DEFAULT_PYTHON_VERSION = "3.10"
 
 UNIT_TEST_PYTHON_VERSIONS: List[str] = [
     "3.7",
@@ -56,7 +56,7 @@ UNIT_TEST_DEPENDENCIES: List[str] = []
 UNIT_TEST_EXTRAS: List[str] = []
 UNIT_TEST_EXTRAS_BY_PYTHON: Dict[str, List[str]] = {}
 
-SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.8"]
+SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.10"]
 SYSTEM_TEST_STANDARD_DEPENDENCIES: List[str] = [
     "mock",
     "pytest",

--- a/noxfile.py
+++ b/noxfile.py
@@ -56,7 +56,7 @@ UNIT_TEST_DEPENDENCIES: List[str] = []
 UNIT_TEST_EXTRAS: List[str] = []
 UNIT_TEST_EXTRAS_BY_PYTHON: Dict[str, List[str]] = {}
 
-SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.8"]
+SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.10", "3.11", "3.12", "3.13"]
 SYSTEM_TEST_STANDARD_DEPENDENCIES: List[str] = [
     "mock",
     "pytest",

--- a/owlbot.py
+++ b/owlbot.py
@@ -31,7 +31,7 @@ templated_files = common.py_library(
 s.move(templated_files, excludes=["docs/multiprocessing.rst", "README.rst"])
 
 s.replace(
-    ".kokoro/presubmit.cfg",
+    ".kokoro/presubmit/presubmit.cfg",
     """# Format: //devtools/kokoro/config/proto/build.proto""",
     """# Format: //devtools/kokoro/config/proto/build.proto
 

--- a/owlbot.py
+++ b/owlbot.py
@@ -37,7 +37,7 @@ s.replace(
 
 env_vars: {
     key: "NOX_SESSION"
-    value: "system-3.10 blacken format"
+    value: "system blacken format"
 }""",
 )
 

--- a/owlbot.py
+++ b/owlbot.py
@@ -51,5 +51,19 @@ s.replace(
     session.install\("--pre", "grpcio!=1.52.0rc1"\)""",
     ""
 )
+
+s.replace(
+    "noxfile.py",
+    "DEFAULT_PYTHON_VERSION = '3.8'",
+    "DEFAULT_PYTHON_VERSION = '3.10'"
+)
+
+s.replace(
+    "noxfile.py",
+    "SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ['3.8']",
+    "SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ['3.10']"
+)
+
+
 s.shell.run(["nox", "-s", "blacken"], hide_output=False)
 

--- a/owlbot.py
+++ b/owlbot.py
@@ -31,6 +31,12 @@ templated_files = common.py_library(
 s.move(templated_files, excludes=["docs/multiprocessing.rst", "README.rst"])
 
 s.replace(
+    ".github/workflows/lint.yml",
+    'python-version: "3.8"',
+    'python-version: "3.10"'
+)
+
+s.replace(
     ".kokoro/presubmit/presubmit.cfg",
     """# Format: //devtools/kokoro/config/proto/build.proto""",
     """# Format: //devtools/kokoro/config/proto/build.proto

--- a/owlbot.py
+++ b/owlbot.py
@@ -60,7 +60,7 @@ s.replace(
 
 s.replace(
     "noxfile.py",
-    'SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.8"]',
+    'SYSTEM_TEST_PYTHON_VERSIONS: List[str] = \["3.8"\]',
     'SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.10", "3.11", "3.12", "3.13"]'
 )
 

--- a/owlbot.py
+++ b/owlbot.py
@@ -60,7 +60,7 @@ s.replace(
 
 s.replace(
     "noxfile.py",
-    r'SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.8"]',
+    r'SYSTEM_TEST_PYTHON_VERSIONS: List\[str\] = \["3.8"\]',
     'SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.10", "3.11", "3.12", "3.13"]'
 )
 

--- a/owlbot.py
+++ b/owlbot.py
@@ -27,6 +27,8 @@ common = gcp.CommonTemplates()
 # ----------------------------------------------------------------------------
 templated_files = common.py_library(
     microgenerator=True,
+    default_python_version="3.10",
+    system_test_python_versions=["3.10"],
 )
 s.move(templated_files, excludes=["docs/multiprocessing.rst", "README.rst"])
 
@@ -57,19 +59,6 @@ s.replace(
     session.install\("--pre", "grpcio!=1.52.0rc1"\)""",
     ""
 )
-
-s.replace(
-    "noxfile.py",
-    'DEFAULT_PYTHON_VERSION = "3.8"',
-    'DEFAULT_PYTHON_VERSION = "3.10"'
-)
-
-s.replace(
-    "noxfile.py",
-    r'SYSTEM_TEST_PYTHON_VERSIONS: List\[str\] = \["3.8"\]',
-    'SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.10"]'
-)
-
 
 s.shell.run(["nox", "-s", "blacken"], hide_output=False)
 

--- a/owlbot.py
+++ b/owlbot.py
@@ -37,7 +37,7 @@ s.replace(
 
 env_vars: {
     key: "NOX_SESSION"
-    value: "system-3.8 blacken format"
+    value: "system-3.10 blacken format"
 }""",
 )
 

--- a/owlbot.py
+++ b/owlbot.py
@@ -30,6 +30,17 @@ templated_files = common.py_library(
 )
 s.move(templated_files, excludes=["docs/multiprocessing.rst", "README.rst"])
 
+s.replace(
+    ".kokoro/presubmit.cfg",
+    """# Format: //devtools/kokoro/config/proto/build.proto""",
+    """# Format: //devtools/kokoro/config/proto/build.proto
+
+env_vars: {
+    key: "NOX_SESSION"
+    value: "system-3.12 blacken mypy format"
+}""",
+)
+
 python.py_samples(skip_readmes=True)
 
 s.replace(

--- a/owlbot.py
+++ b/owlbot.py
@@ -54,14 +54,14 @@ s.replace(
 
 s.replace(
     "noxfile.py",
-    "DEFAULT_PYTHON_VERSION = '3.8'",
-    "DEFAULT_PYTHON_VERSION = '3.10'"
+    'DEFAULT_PYTHON_VERSION = "3.8"',
+    'DEFAULT_PYTHON_VERSION = "3.10"'
 )
 
 s.replace(
     "noxfile.py",
-    "SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ['3.8']",
-    "SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ['3.10', '3.11', '3.12', '3.13']"
+    'SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.8"]',
+    'SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.10", "3.11", "3.12", "3.13"]'
 )
 
 

--- a/owlbot.py
+++ b/owlbot.py
@@ -61,7 +61,7 @@ s.replace(
 s.replace(
     "noxfile.py",
     "SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ['3.8']",
-    "SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ['3.10']"
+    "SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ['3.10', '3.11', '3.12', '3.13']"
 )
 
 

--- a/owlbot.py
+++ b/owlbot.py
@@ -37,7 +37,7 @@ s.replace(
 
 env_vars: {
     key: "NOX_SESSION"
-    value: "system-3.12 blacken mypy format"
+    value: "system-3.8 blacken format"
 }""",
 )
 

--- a/owlbot.py
+++ b/owlbot.py
@@ -60,7 +60,7 @@ s.replace(
 
 s.replace(
     "noxfile.py",
-    'SYSTEM_TEST_PYTHON_VERSIONS: List[str] = \["3.8"\]',
+    r'SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.8"]',
     'SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.10", "3.11", "3.12", "3.13"]'
 )
 

--- a/owlbot.py
+++ b/owlbot.py
@@ -61,7 +61,7 @@ s.replace(
 s.replace(
     "noxfile.py",
     r'SYSTEM_TEST_PYTHON_VERSIONS: List\[str\] = \["3.8"\]',
-    'SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.10", "3.11", "3.12", "3.13"]'
+    'SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.10"]'
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Operating System :: OS Independent",
         "Topic :: Internet",
     ],

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
+        'Programming Language :: Python :: 3.13',
         "Operating System :: OS Independent",
         "Topic :: Internet",
     ],

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
+        'Programming Language :: Python :: 3.13",
         "Operating System :: OS Independent",
         "Topic :: Internet",
     ],

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
-        'Programming Language :: Python :: 3.13',
+        "Programming Language :: Python :: 3.13",
         "Operating System :: OS Independent",
         "Topic :: Internet",
     ],

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
-        'Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.13",
         "Operating System :: OS Independent",
         "Topic :: Internet",
     ],


### PR DESCRIPTION
This PR introduces support for Python 3.13 and makes several updates to the CI and testing configuration:

#### Python 3.13 Support:
   - Adds Python 3.13 to the classifiers in setup.py.
   - A constraints-3.13.txt file was already present.

#### CI/Testing Updates:
   - Updates the default Python version for linting in `.github/workflows/lint.yml` from 3.8 to 3.10 to mirror other defaults in the nox sessions for system tests, etc.
   - Sets the `NOX_SESSION` environment variable in `.kokoro/presubmit/presubmit.cfg` to "system blacken format" to control which nox sessions run during presubmit
   - Changes `DEFAULT_PYTHON_VERSION` in noxfile.py from 3.8 to 3.10.
   - Updates `SYSTEM_TEST_PYTHON_VERSIONS` in noxfile.py from 3.8 to 3.10.

#### Owlbot Configuration:
   - Adds `s.replace` calls in `owlbot.py` to persist the changes in `lint.yml`, `presubmit.cfg`, and `noxfile.py` after owlbot post-processing. This ensures that the CI environment and test configurations use Python 3.10 by default and that the presubmit runs a specific set of nox sessions.

These changes ensure that Python 3.13 is supported and that the CI environment defaults to Python 3.10 for system tests and linting, working around known issues with older Python versions (3.7 and 3.8) in the Kokoro Docker python-multi image.
