### PR TITLE
Feat: add support for Python 3.14

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -22,7 +22,7 @@ In order to add a feature:
   documentation.
 
 - The feature must work fully on the following CPython versions:
-  3.7, 3.8, 3.9, 3.10, 3.11, 3.12 and 3.13 on both UNIX and Windows.
+  3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13 and 3.14 on both UNIX and Windows.
 
 - The feature must not add unnecessary dependencies (where
   "unnecessary" is of course subjective, but new dependencies should
@@ -72,7 +72,7 @@ We use `nox <https://nox.readthedocs.io/en/latest/>`__ to instrument our tests.
 
 - To run a single unit test::
 
-    $ nox -s unit-3.13 -- -k <name of test>
+    $ nox -s unit-3.14 -- -k <name of test>
 
 
   .. note::
@@ -228,6 +228,7 @@ We support:
 -  `Python 3.11`_
 -  `Python 3.12`_
 -  `Python 3.13`_
+-  `Python 3.14`_
 
 .. _Python 3.7: https://docs.python.org/3.7/
 .. _Python 3.8: https://docs.python.org/3.8/
@@ -236,6 +237,7 @@ We support:
 .. _Python 3.11: https://docs.python.org/3.11/
 .. _Python 3.12: https://docs.python.org/3.12/
 .. _Python 3.13: https://docs.python.org/3.13/
+.. _Python 3.14: https://docs.python.org/3.14/
 
 
 Supported versions can be found in our ``noxfile.py`` `config`_.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -22,7 +22,7 @@ In order to add a feature:
   documentation.
 
 - The feature must work fully on the following CPython versions:
-  3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13 and 3.14 on both UNIX and Windows.
+  3.7, 3.8, 3.9, 3.10, 3.11, 3.12 and 3.13 on both UNIX and Windows.
 
 - The feature must not add unnecessary dependencies (where
   "unnecessary" is of course subjective, but new dependencies should
@@ -228,7 +228,6 @@ We support:
 -  `Python 3.11`_
 -  `Python 3.12`_
 -  `Python 3.13`_
--  `Python 3.14`_
 
 .. _Python 3.7: https://docs.python.org/3.7/
 .. _Python 3.8: https://docs.python.org/3.8/
@@ -237,7 +236,6 @@ We support:
 .. _Python 3.11: https://docs.python.org/3.11/
 .. _Python 3.12: https://docs.python.org/3.12/
 .. _Python 3.13: https://docs.python.org/3.13/
-.. _Python 3.14: https://docs.python.org/3.14/
 
 
 Supported versions can be found in our ``noxfile.py`` `config`_.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -22,7 +22,7 @@ In order to add a feature:
   documentation.
 
 - The feature must work fully on the following CPython versions:
-  3.7, 3.8, 3.9, 3.10, 3.11, 3.12 and 3.13 on both UNIX and Windows.
+  3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13 and 3.14 on both UNIX and Windows.
 
 - The feature must not add unnecessary dependencies (where
   "unnecessary" is of course subjective, but new dependencies should
@@ -228,6 +228,7 @@ We support:
 -  `Python 3.11`_
 -  `Python 3.12`_
 -  `Python 3.13`_
+-  `Python 3.14`_
 
 .. _Python 3.7: https://docs.python.org/3.7/
 .. _Python 3.8: https://docs.python.org/3.8/
@@ -236,6 +237,7 @@ We support:
 .. _Python 3.11: https://docs.python.org/3.11/
 .. _Python 3.12: https://docs.python.org/3.12/
 .. _Python 3.13: https://docs.python.org/3.13/
+.. _Python 3.14: https://docs.python.org/3.14/
 
 
 Supported versions can be found in our ``noxfile.py`` `config`_.

--- a/noxfile.py
+++ b/noxfile.py
@@ -42,7 +42,6 @@ UNIT_TEST_PYTHON_VERSIONS: List[str] = [
     "3.11",
     "3.12",
     "3.13",
-    "3.14",
 ]
 UNIT_TEST_STANDARD_DEPENDENCIES = [
     "mock",
@@ -176,7 +175,7 @@ def install_unittest_dependencies(session, *constraints):
 def unit(session, protobuf_implementation):
     # Install all test dependencies, then install this package in-place.
 
-    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13", "3.14"):
+    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13"):
         session.skip("cpp implementation is not supported in python 3.11+")
 
     constraints_path = str(
@@ -371,7 +370,7 @@ def docfx(session):
     )
 
 
-@nox.session(python="3.14")
+@nox.session(python="3.13")
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb", "cpp"],
@@ -379,7 +378,7 @@ def docfx(session):
 def prerelease_deps(session, protobuf_implementation):
     """Run all tests with prerelease versions of dependencies installed."""
 
-    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13", "3.14"):
+    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13"):
         session.skip("cpp implementation is not supported in python 3.11+")
 
     # Install all dependencies

--- a/noxfile.py
+++ b/noxfile.py
@@ -371,7 +371,7 @@ def docfx(session):
     )
 
 
-@nox.session(python='3.14')
+@nox.session(python="3.14")
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb", "cpp"],

--- a/noxfile.py
+++ b/noxfile.py
@@ -176,7 +176,12 @@ def install_unittest_dependencies(session, *constraints):
 def unit(session, protobuf_implementation):
     # Install all test dependencies, then install this package in-place.
 
-    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13"):
+    if protobuf_implementation == "cpp" and session.python in (
+        "3.11",
+        "3.12",
+        "3.13",
+        "3.14",
+    ):
         session.skip("cpp implementation is not supported in python 3.11+")
 
     constraints_path = str(
@@ -379,7 +384,12 @@ def docfx(session):
 def prerelease_deps(session, protobuf_implementation):
     """Run all tests with prerelease versions of dependencies installed."""
 
-    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13"):
+    if protobuf_implementation == "cpp" and session.python in (
+        "3.11",
+        "3.12",
+        "3.13",
+        "3.14",
+    ):
         session.skip("cpp implementation is not supported in python 3.11+")
 
     # Install all dependencies

--- a/noxfile.py
+++ b/noxfile.py
@@ -42,6 +42,7 @@ UNIT_TEST_PYTHON_VERSIONS: List[str] = [
     "3.11",
     "3.12",
     "3.13",
+    "3.14",
 ]
 UNIT_TEST_STANDARD_DEPENDENCIES = [
     "mock",
@@ -175,7 +176,7 @@ def install_unittest_dependencies(session, *constraints):
 def unit(session, protobuf_implementation):
     # Install all test dependencies, then install this package in-place.
 
-    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13"):
+    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13", "3.14"):
         session.skip("cpp implementation is not supported in python 3.11+")
 
     constraints_path = str(
@@ -370,7 +371,7 @@ def docfx(session):
     )
 
 
-@nox.session(python="3.13")
+@nox.session(python="3.14")
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb", "cpp"],
@@ -378,7 +379,7 @@ def docfx(session):
 def prerelease_deps(session, protobuf_implementation):
     """Run all tests with prerelease versions of dependencies installed."""
 
-    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13"):
+    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13", "3.14"):
         session.skip("cpp implementation is not supported in python 3.11+")
 
     # Install all dependencies

--- a/noxfile.py
+++ b/noxfile.py
@@ -42,6 +42,7 @@ UNIT_TEST_PYTHON_VERSIONS: List[str] = [
     "3.11",
     "3.12",
     "3.13",
+    "3.14",
 ]
 UNIT_TEST_STANDARD_DEPENDENCIES = [
     "mock",
@@ -370,7 +371,7 @@ def docfx(session):
     )
 
 
-@nox.session(python="3.13")
+@nox.session(python="3.14")
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb", "cpp"],

--- a/noxfile.py
+++ b/noxfile.py
@@ -371,7 +371,7 @@ def docfx(session):
     )
 
 
-@nox.session(python="3.14")
+@nox.session(python='3.14')
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb", "cpp"],

--- a/owlbot.py
+++ b/owlbot.py
@@ -36,7 +36,8 @@ s.move(templated_files, excludes=["docs/multiprocessing.rst", "README.rst"])
 s.replace(
     "noxfile.py",
     '''session.python in ("3.11", "3.12", "3.13")''',
-    '''session.python in ("3.11", "3.12", "3.13", "3.14")'''
+    'session.python in \("3.11", "3.12", "3.13"\)',
+    'session.python in ("3.11", "3.12", "3.13", "3.14")'
 )
 
 s.replace(

--- a/owlbot.py
+++ b/owlbot.py
@@ -33,12 +33,6 @@ templated_files = common.py_library(
 s.move(templated_files, excludes=["docs/multiprocessing.rst", "README.rst"])
 
 s.replace(
-    ".github/workflows/lint.yml",
-    'python-version: "3.8"',
-    'python-version: "3.10"'
-)
-
-s.replace(
     ".kokoro/presubmit/presubmit.cfg",
     """# Format: //devtools/kokoro/config/proto/build.proto""",
     """# Format: //devtools/kokoro/config/proto/build.proto

--- a/owlbot.py
+++ b/owlbot.py
@@ -34,6 +34,12 @@ templated_files = common.py_library(
 s.move(templated_files, excludes=["docs/multiprocessing.rst", "README.rst"])
 
 s.replace(
+    "noxfile.py",
+    '''session.python in ("3.11", "3.12", "3.13")''',
+    '''session.python in ("3.11", "3.12", "3.13", "3.14")'''
+)
+
+s.replace(
     ".kokoro/presubmit/presubmit.cfg",
     """# Format: //devtools/kokoro/config/proto/build.proto""",
     """# Format: //devtools/kokoro/config/proto/build.proto

--- a/owlbot.py
+++ b/owlbot.py
@@ -28,6 +28,7 @@ common = gcp.CommonTemplates()
 templated_files = common.py_library(
     microgenerator=True,
     default_python_version="3.10",
+    unit_test_python_versions=["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"],
     system_test_python_versions=["3.10"],
 )
 s.move(templated_files, excludes=["docs/multiprocessing.rst", "README.rst"])

--- a/owlbot.py
+++ b/owlbot.py
@@ -35,7 +35,6 @@ s.move(templated_files, excludes=["docs/multiprocessing.rst", "README.rst"])
 
 s.replace(
     "noxfile.py",
-    '''session.python in ("3.11", "3.12", "3.13")''',
     'session.python in \("3.11", "3.12", "3.13"\)',
     'session.python in ("3.11", "3.12", "3.13", "3.14")'
 )

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Operating System :: OS Independent",
         "Topic :: Internet",
     ],


### PR DESCRIPTION
This PR introduces support for Python 3.14:

Python 3.14 Support:
    - Adds Python 3.14 to the classifiers in `setup.py`.
    - Creates `testing/constraints-3.14.txt` (copied from 3.13 constraints).
    - Updates `CONTRIBUTING.rst` to list Python 3.14 as a supported version.
    - Adds Python 3.14 to the test matrix in `.github/workflows/unittest.yml`.
    - Updates `noxfile.py` to include "3.14" in `UNIT_TEST_PYTHON_VERSIONS` and relevant version checks.

These changes ensure that the library is tested and officially supports Python 3.14.