### PR TITLE
test: remove python 3.7 and 3.8 from noxfile unit tests

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -72,7 +72,12 @@ SYSTEM_TEST_EXTRAS_BY_PYTHON: Dict[str, List[str]] = {}
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
 nox.options.sessions = [
-    "unit",
+    "unit-3.9",
+    "unit-3.10",
+    "unit-3.11",
+    "unit-3.12",
+    "unit-3.13",
+    "unit-3.14",
     "system",
     "cover",
     "lint",

--- a/noxfile.py
+++ b/noxfile.py
@@ -72,12 +72,7 @@ SYSTEM_TEST_EXTRAS_BY_PYTHON: Dict[str, List[str]] = {}
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
 nox.options.sessions = [
-    "unit-3.9",
-    "unit-3.10",
-    "unit-3.11",
-    "unit-3.12",
-    "unit-3.13",
-    "unit-3.14",
+    "unit",
     "system",
     "cover",
     "lint",
@@ -180,9 +175,6 @@ def install_unittest_dependencies(session, *constraints):
 )
 def unit(session, protobuf_implementation):
     # Install all test dependencies, then install this package in-place.
-
-    if session.python in ("3.7", "3.8") and os.environ.get("TRAMPOLINE_IMAGE"):
-        session.skip("skipping Python 3.7 and 3.8 in kokoro tests")
 
     if protobuf_implementation == "cpp" and session.python in (
         "3.11",

--- a/noxfile.py
+++ b/noxfile.py
@@ -72,7 +72,12 @@ SYSTEM_TEST_EXTRAS_BY_PYTHON: Dict[str, List[str]] = {}
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
 nox.options.sessions = [
-    "unit",
+    "unit-3.9",
+    "unit-3.10",
+    "unit-3.11",
+    "unit-3.12",
+    "unit-3.13",
+    "unit-3.14",
     "system",
     "cover",
     "lint",
@@ -175,6 +180,9 @@ def install_unittest_dependencies(session, *constraints):
 )
 def unit(session, protobuf_implementation):
     # Install all test dependencies, then install this package in-place.
+
+    if session.python in ("3.7", "3.8") and os.environ.get("TRAMPOLINE_IMAGE"):
+        session.skip("skipping Python 3.7 and 3.8 in kokoro tests")
 
     if protobuf_implementation == "cpp" and session.python in (
         "3.11",

--- a/noxfile.py
+++ b/noxfile.py
@@ -72,12 +72,7 @@ SYSTEM_TEST_EXTRAS_BY_PYTHON: Dict[str, List[str]] = {}
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
 nox.options.sessions = [
-    "unit-3.9",
-    "unit-3.10",
-    "unit-3.11",
-    "unit-3.12",
-    "unit-3.13",
-    "unit-3.14",
+    "unit",
     "system",
     "cover",
     "lint",

--- a/owlbot.py
+++ b/owlbot.py
@@ -41,7 +41,7 @@ s.replace(
 
 s.replace(
     "noxfile.py",
-    """nox.options.sessions = [
+    """nox.options.sessions = \[
     "unit",
 	""",
     """nox.options.sessions = [

--- a/owlbot.py
+++ b/owlbot.py
@@ -40,6 +40,21 @@ s.replace(
 )
 
 s.replace(
+    "noxfile.py",
+    """nox.options.sessions = [
+    "unit",
+	""",
+    """nox.options.sessions = [
+    "unit-3.9",
+    "unit-3.10",
+    "unit-3.11",
+    "unit-3.12",
+    "unit-3.13",
+    "unit-3.14",
+	""",
+)
+
+s.replace(
     ".kokoro/presubmit/presubmit.cfg",
     """# Format: //devtools/kokoro/config/proto/build.proto""",
     """# Format: //devtools/kokoro/config/proto/build.proto

--- a/owlbot.py
+++ b/owlbot.py
@@ -41,7 +41,7 @@ s.replace(
 
 s.replace(
     "noxfile.py",
-    """nox.options.sessions = \[
+    """nox\.options\.sessions = \[
     "unit",
 	""",
     """nox.options.sessions = [


### PR DESCRIPTION
Continuous test has been failing due to removed Python 3.7 and 3.8 in the docker image, while the nox session still tries to run unit-3.7 and unit-3.8. This PR makes the change so we still run unit-3.7 and unit-3.8 in presubmit via github action, but skip them in continuous test.