### PR TITLE
tests: update default python runtime for tests to 3.14

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.14"
     - name: Install nox
       run: |
         python -m pip install --upgrade setuptools pip wheel

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.14"
     - name: Install coverage
       run: |
         python -m pip install --upgrade setuptools pip wheel

--- a/noxfile.py
+++ b/noxfile.py
@@ -141,7 +141,7 @@ def format(session):
 @nox.session(python=DEFAULT_PYTHON_VERSION)
 def lint_setup_py(session):
     """Verify that setup.py is valid (including RST check)."""
-    session.install("docutils", "pygments")
+    session.install("docutils", "pygments", "setuptools")
     session.run("python", "setup.py", "check", "--restructuredtext", "--strict")
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -32,7 +32,7 @@ BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
-DEFAULT_PYTHON_VERSION = "3.10"
+DEFAULT_PYTHON_VERSION = "3.14"
 
 UNIT_TEST_PYTHON_VERSIONS: List[str] = [
     "3.7",
@@ -381,7 +381,7 @@ def docfx(session):
     )
 
 
-@nox.session(python="3.14")
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 @nox.parametrize(
     "protobuf_implementation",
     ["python", "upb", "cpp"],


### PR DESCRIPTION
Similar to https://github.com/googleapis/python-api-core/pull/870